### PR TITLE
chore: add classname for clickable images in columns block

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -679,19 +679,37 @@
         "label": "Rows"
       },
       {
-        "component": "select",
+        "component": "multiselect",
         "valueType": "string",
         "name": "classes",
         "value": "",
         "label": "Columns Style",
         "options": [
           {
-            "name": "Content centered",
-            "value": "content-center"
+            "name": "Content alignment",
+            "children": [
+              {
+                "name": "Content centered",
+                "value": "content-center"
+              },
+              {
+                "name": "Content left aligned",
+                "value": "content-left"
+              }
+            ]
           },
           {
-            "name": "Content left aligned",
-            "value": "content-left"
+            "name": "Clickable Images",
+            "children": [
+              {
+                "name": "Yes",
+                "value": "clickable-images"
+              },
+              {
+                "name": "No",
+                "value": ""
+              }
+            ]
           }
         ]
       }

--- a/component-models.json
+++ b/component-models.json
@@ -665,20 +665,6 @@
     "id": "columns",
     "fields": [
       {
-        "component": "text",
-        "valueType": "number",
-        "name": "columns",
-        "value": "",
-        "label": "Columns"
-      },
-      {
-        "component": "text",
-        "valueType": "number",
-        "name": "rows",
-        "value": "",
-        "label": "Rows"
-      },
-      {
         "component": "multiselect",
         "valueType": "string",
         "name": "classes",
@@ -712,6 +698,20 @@
             ]
           }
         ]
+      },
+      {
+        "component": "text",
+        "valueType": "number",
+        "name": "columns",
+        "value": "",
+        "label": "Columns"
+      },
+      {
+        "component": "text",
+        "valueType": "number",
+        "name": "rows",
+        "value": "",
+        "label": "Rows"
       }
     ]
   },


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #21 

Test URLs:
- Before: https://main--piramal--aemsites.hlx.page/footer
- After: https://issue-22--piramal--aemsites.hlx.page/footer