### PR TITLE
#10 Testimonals Block: add styles for floating  heads

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -225,7 +225,8 @@
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
                   "name": "Testimonies",
-                  "filter": "testimonies"
+                  "filter": "testimonies",
+                  "model": "testimonies"
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -727,11 +727,11 @@
         "options": [
           {
             "name": "With floating Heads",
-            "value": "floating-heads"
+            "value": "float"
           },
           {
             "name": "Without floating Heads",
-            "value": "no-floating-heads"
+            "value": "no-float"
           }
         ]
       }

--- a/component-models.json
+++ b/component-models.json
@@ -727,7 +727,7 @@
         "options": [
           {
             "name": "With floating Heads",
-            "value": "float"
+            "value": ""
           },
           {
             "name": "Without floating Heads",

--- a/component-models.json
+++ b/component-models.json
@@ -727,11 +727,11 @@
         "options": [
           {
             "name": "With floating Heads",
-            "value": ""
+            "value": "floating-heads"
           },
           {
             "name": "Without floating Heads",
-            "value": "floating-heads"
+            "value": "no-floating-heads"
           }
         ]
       }

--- a/component-models.json
+++ b/component-models.json
@@ -718,6 +718,23 @@
   {
     "id": "testimonies",
     "fields": [
+      {
+        "component": "select",
+        "valueType": "string",
+        "name": "classes",
+        "value": "",
+        "label": "Style",
+        "options": [
+          {
+            "name": "With floating Heads",
+            "value": ""
+          },
+          {
+            "name": "Without floating Heads",
+            "value": "floating-heads"
+          }
+        ]
+      }
     ]
   },
   {


### PR DESCRIPTION
The testimonials block has to different rendering styles , with and without floating heads. The PR adds a styles/classes option to choose between these two:

Before:
![image](https://github.com/user-attachments/assets/60608d01-b70d-447d-81cf-d81780a91b72)
https://author-p133703-e1305981.adobeaemcloud.com/ui#/@piramal/aem/universal-editor/canvas/author-p133703-e1305981.adobeaemcloud.com/content/piramalfinance-eds2/index.html

After:
![image](https://github.com/user-attachments/assets/943599e3-7d76-4d6a-ba95-221de6125063)
https://author-p133703-e1305981.adobeaemcloud.com/ui#/@piramal/aem/universal-editor/canvas/author-p133703-e1305981.adobeaemcloud.com/content/piramalfinance-eds2/index.html?ref=10-testimonials-styles

Notes: 
- default is floating heads (no class set)
- class for no floating heads is `no-float`
- 
Fix # 11


