### PR TITLE
Testimonies richtext to p

### DIFF
--- a/blocks/testimonies/testimonies.css
+++ b/blocks/testimonies/testimonies.css
@@ -53,7 +53,7 @@
   border-bottom: 30px solid white;
 }
 
-.block.testimonies .testimony.selected .testimony-content > p {
+.block.testimonies .testimony.selected .testimony-content p {
   text-align: center;
   margin: 0;
   font-size: 1.125rem;
@@ -274,4 +274,8 @@
   100% {
     transform: translateY(0);
   }
+}
+
+.block.testimonies.no-float .testimony.unselected {
+  display: none;
 }

--- a/blocks/testimonies/testimonies.js
+++ b/blocks/testimonies/testimonies.js
@@ -22,10 +22,10 @@ export default function decorate(block) {
     img.classList.add('testimony-img');
     content.classList.add('testimony-content');
 
-    const [desc, name, title] = content.querySelectorAll(':scope > *');
-    desc.classList.add('testimony-desc');
-    name.classList.add('testimony-name');
-    title.classList.add('testimony-title');
+    const [desc, name, title] = content.querySelectorAll(':scope p');
+    desc?.classList?.add('testimony-desc');
+    name?.classList?.add('testimony-name');
+    title?.classList?.add('testimony-title');
 
     const confetti = [
       document.createElement('img'),

--- a/blocks/testimonies/testimonies.js
+++ b/blocks/testimonies/testimonies.js
@@ -34,7 +34,7 @@ export default function decorate(block) {
       document.createElement('img'),
     ].map((conf, i) => {
       conf.classList.add(`confetti-${i + 1}`, 'confetti');
-      conf.src = `/icons/confetti-${i + 1}.svg`;
+      conf.src = `${window.hlx.codeBasePath}/icons/confetti-${i + 1}.svg`;
       conf.alt = 'confetti icon';
       return conf;
     });


### PR DESCRIPTION
- When the page is opened in UE, it wraps richtext in a div so you can edit multipe paragraphs within the same richtext property. When published the div is no longer added. So the code has to be aware of this.
- fixed links to static confetti images coming from github

Fix none

Test URLs:
- Before: https://main--piramal--aemsites.hlx.page
- After: https://testimonies-richtext-to-p--piramal--aemsites.hlx.page
