### PR TITLE
feat: set placeholder context as block option

### DIFF
--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -4,33 +4,38 @@
  * https://www.hlx.live/developer/block-collection/table
  */
 
-function buildCell(rowIndex) {
-  const cell = rowIndex ? document.createElement('td') : document.createElement('th');
-  if (!rowIndex) cell.setAttribute('scope', 'col');
-  return cell;
-}
+import { moveInstrumentation } from '../../scripts/scripts.js';
 
 export default async function decorate(block) {
   const table = document.createElement('table');
-  const thead = document.createElement('thead');
   const tbody = document.createElement('tbody');
+  const [header, ...rows] = [...block.children];
 
-  const header = !block.classList.contains('no-header');
-  if (header) {
+  if (header.textContent.trim()) {
+    const thead = document.createElement('thead');
+    const tr = document.createElement('tr');
+    header.querySelectorAll('p').forEach((p) => {
+      const th = document.createElement('th');
+      th.setAttribute('scope', 'col');
+      moveInstrumentation(p, th);
+      th.innerHTML = p.innerHTML;
+      tr.append(th);
+    });
+    thead.append(tr);
     table.append(thead);
   }
-  table.append(tbody);
 
-  [...block.children].forEach((child, i) => {
+  [...rows].forEach((child) => {
     const row = document.createElement('tr');
-    if (header && i === 0) thead.append(row);
-    else tbody.append(row);
+    moveInstrumentation(child, row);
     [...child.children].forEach((col) => {
-      const cell = buildCell(header ? i : i + 1);
+      const cell = document.createElement('td');
       cell.innerHTML = col.innerHTML;
       row.append(cell);
     });
+    tbody.append(row);
   });
-  block.innerHTML = '';
-  block.append(table);
+
+  table.append(tbody);
+  block.replaceChildren(table);
 }

--- a/component-definition.json
+++ b/component-definition.json
@@ -338,11 +338,11 @@
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
-                  "name": "Fee & Charges",
+                  "name": "Table",
                   "model": "fee-charges",
                   "filter": "fee-charges",
-                  "column1title": "Features & Fees",
-                  "column2title": "Details"
+                  "titles_column1title": "Features & Fees",
+                  "titles_column2title": "Details"
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -931,24 +931,65 @@
     "id": "fee-charges",
     "fields": [
       {
+        "component": "multiselect",
+        "name": "classes",
+        "value": "",
+        "label": "Options",
+        "valueType": "string",
+        "maxSize": 2,
+        "options": [
+          {
+            "name": "Currency Format",
+            "children": [
+              {
+                "name": "Long",
+                "value": "currency-format-long"
+              },
+              {
+                "name": "Short (Phonetic)",
+                "value": "currency-format-phonetic"
+              },
+              {
+                "name": "Short",
+                "value": "currency-format-short"
+              }
+            ]
+          },
+          {
+            "name": "Loan Context",
+            "children": [
+              {
+                "name": "Home Loans",
+                "value": "loan-type-home"
+              },
+              {
+                "name": "Business Loans",
+                "value": "loan-type-business"
+              },
+              {
+                "name": "Personal Loans",
+                "value": "loan-type-personal"
+              },
+              {
+                "name": "Construction Loans",
+                "value": "loan-type-construction"
+              }
+            ]
+          }
+        ]
+      },
+      {
         "component": "text",
         "valueType": "string",
-        "name": "loan-type",
-        "label": "Loan Type",
+        "name": "titles_column1title",
+        "label": "First Column",
         "multi": false
       },
       {
         "component": "text",
         "valueType": "string",
-        "name": "column1title",
-        "label": "Title First Column",
-        "multi": false
-      },
-      {
-        "component": "text",
-        "valueType": "string",
-        "name": "column2title",
-        "label": "Title Second Column",
+        "name": "titles_column2title",
+        "label": "Second Column",
         "multi": false
       }
     ]
@@ -997,7 +1038,7 @@
         "valueType": "string",
         "name": "article_image",
         "label": "Article Image",
-        "required" : true,
+        "required": true,
         "multi": false
       },
       {
@@ -1017,7 +1058,7 @@
         "valueType": "string",
         "name": "article_link",
         "label": "Article Link",
-        "required" : true,
+        "required": true,
         "multi": false
       },
       {
@@ -1099,7 +1140,7 @@
         "valueType": "string",
         "name": "card_image",
         "label": "Image",
-        "required" : true,
+        "required": true,
         "multi": false
       },
       {


### PR DESCRIPTION
- Use a multi select to configure loan-type and currency-format as block option.
- Put column titles in a single cell
- Use table block

<img width="308" alt="Screenshot 2024-07-26 at 11 28 02" src="https://github.com/user-attachments/assets/4510156c-3ab3-41b1-b7ad-bd8eeaa80d23">

