### PR TITLE
feat: placeholder replacement

### DIFF
--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -41,6 +41,16 @@
   text-align: left;
 }
 
+.table table th :first-child,
+.table table td :first-child {
+  margin-top: 0;
+}
+
+.table table th :last-child,
+.table table td :last-child {
+  margin-bottom: 0;
+}
+
 /* no header variant */
 .table.no-header table tbody tr {
   border-top: 1px solid;

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -4,33 +4,38 @@
  * https://www.hlx.live/developer/block-collection/table
  */
 
-function buildCell(rowIndex) {
-  const cell = rowIndex ? document.createElement('td') : document.createElement('th');
-  if (!rowIndex) cell.setAttribute('scope', 'col');
-  return cell;
-}
+import { moveInstrumentation } from '../../scripts/scripts.js';
 
 export default async function decorate(block) {
   const table = document.createElement('table');
-  const thead = document.createElement('thead');
   const tbody = document.createElement('tbody');
+  const [header, ...rows] = [...block.children];
 
-  const header = !block.classList.contains('no-header');
-  if (header) {
+  if (header.textContent.trim()) {
+    const thead = document.createElement('thead');
+    const tr = document.createElement('tr');
+    header.querySelectorAll('p').forEach((p) => {
+      const th = document.createElement('th');
+      th.setAttribute('scope', 'col');
+      moveInstrumentation(p, th);
+      th.innerHTML = p.innerHTML;
+      tr.append(th);
+    });
+    thead.append(tr);
     table.append(thead);
   }
-  table.append(tbody);
 
-  [...block.children].forEach((child, i) => {
+  [...rows].forEach((child) => {
     const row = document.createElement('tr');
-    if (header && i === 0) thead.append(row);
-    else tbody.append(row);
+    moveInstrumentation(child, row);
     [...child.children].forEach((col) => {
-      const cell = buildCell(header ? i : i + 1);
+      const cell = document.createElement('td');
       cell.innerHTML = col.innerHTML;
       row.append(cell);
     });
+    tbody.append(row);
   });
-  block.innerHTML = '';
-  block.append(table);
+
+  table.append(tbody);
+  block.replaceChildren(table);
 }

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -4,9 +4,11 @@
  * https://www.hlx.live/developer/block-collection/table
  */
 
-import { moveInstrumentation } from '../../scripts/scripts.js';
+import { moveInstrumentation, replacePlaceholders } from '../../scripts/scripts.js';
 
 export default async function decorate(block) {
+  await replacePlaceholders(block);
+
   const table = document.createElement('table');
   const thead = document.createElement('thead');
   const tbody = document.createElement('tbody');

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -8,34 +8,25 @@ import { moveInstrumentation } from '../../scripts/scripts.js';
 
 export default async function decorate(block) {
   const table = document.createElement('table');
+  const thead = document.createElement('thead');
   const tbody = document.createElement('tbody');
-  const [header, ...rows] = [...block.children];
 
-  if (header.textContent.trim()) {
-    const thead = document.createElement('thead');
+  [...block.children].forEach((row, i) => {
     const tr = document.createElement('tr');
-    header.querySelectorAll('p').forEach((p) => {
-      const th = document.createElement('th');
-      th.setAttribute('scope', 'col');
-      moveInstrumentation(p, th);
-      th.innerHTML = p.innerHTML;
-      tr.append(th);
-    });
-    thead.append(tr);
-    table.append(thead);
-  }
+    moveInstrumentation(row, tr);
 
-  [...rows].forEach((child) => {
-    const row = document.createElement('tr');
-    moveInstrumentation(child, row);
-    [...child.children].forEach((col) => {
-      const cell = document.createElement('td');
-      cell.innerHTML = col.innerHTML;
-      row.append(cell);
+    [...row.children].forEach((cell) => {
+      const td = document.createElement(i === 0 ? 'th' : 'td');
+      if (i === 0) td.setAttribute('scope', 'column');
+      td.innerHTML = cell.innerHTML;
+      tr.append(td);
     });
-    tbody.append(row);
+
+    if (i === 0) thead.append(tr);
+    else tbody.append(tr);
   });
 
+  table.append(thead);
   table.append(tbody);
   block.replaceChildren(table);
 }

--- a/component-definition.json
+++ b/component-definition.json
@@ -344,7 +344,7 @@
                   "header": {
                     "sling:resourceType": "core/franklin/components/block/v1/block",
                     "model": "fee-row",
-                    "name": "Haeader",
+                    "name": "Row",
                     "column1text": "Features & Fees",
                     "column2text": "Details"
                   }

--- a/component-definition.json
+++ b/component-definition.json
@@ -338,11 +338,11 @@
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
-                  "name": "Fee & Charges",
+                  "name": "Table",
                   "model": "fee-charges",
                   "filter": "fee-charges",
-                  "column1title": "Features & Fees",
-                  "column2title": "Details"
+                  "titles_column1title": "Features & Fees",
+                  "titles_column2title": "Details"
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -931,24 +931,65 @@
     "id": "fee-charges",
     "fields": [
       {
+        "component": "multiselect",
+        "name": "classes",
+        "value": "",
+        "label": "Options",
+        "valueType": "string",
+        "maxSize": 2,
+        "options": [
+          {
+            "name": "Currency Format",
+            "children": [
+              {
+                "name": "Long",
+                "value": "currency-format-long"
+              },
+              {
+                "name": "Short (Phonetic)",
+                "value": "currency-format-phonetic"
+              },
+              {
+                "name": "Short",
+                "value": "currency-format-short"
+              }
+            ]
+          },
+          {
+            "name": "Loan Context",
+            "children": [
+              {
+                "name": "Home Loans",
+                "value": "loan-type-home"
+              },
+              {
+                "name": "Business Loans",
+                "value": "loan-type-business"
+              },
+              {
+                "name": "Personal Loans",
+                "value": "loan-type-personal"
+              },
+              {
+                "name": "Construction Loans",
+                "value": "loan-type-construction"
+              }
+            ]
+          }
+        ]
+      },
+      {
         "component": "text",
         "valueType": "string",
-        "name": "loan-type",
-        "label": "Loan Type",
+        "name": "titles_column1title",
+        "label": "First Column",
         "multi": false
       },
       {
         "component": "text",
         "valueType": "string",
-        "name": "column1title",
-        "label": "Title First Column",
-        "multi": false
-      },
-      {
-        "component": "text",
-        "valueType": "string",
-        "name": "column2title",
-        "label": "Title Second Column",
+        "name": "titles_column2title",
+        "label": "Second Column",
         "multi": false
       }
     ]
@@ -997,7 +1038,7 @@
         "valueType": "string",
         "name": "article_image",
         "label": "Article Image",
-        "required" : true,
+        "required": true,
         "multi": false
       },
       {
@@ -1017,7 +1058,7 @@
         "valueType": "string",
         "name": "article_link",
         "label": "Article Link",
-        "required" : true,
+        "required": true,
         "multi": false
       },
       {
@@ -1099,7 +1140,7 @@
         "valueType": "string",
         "name": "card_image",
         "label": "Image",
-        "required" : true,
+        "required": true,
         "multi": false
       },
       {

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -126,22 +126,6 @@ function handleSelection(event) {
   }
 }
 
-function attachEventListners(main) {
-  [
-    'aue:content-patch',
-    'aue:content-update',
-    'aue:content-add',
-    'aue:content-move',
-    'aue:content-remove',
-  ].forEach((eventType) => main?.addEventListener(eventType, async (event) => {
-    event.stopPropagation();
-    const applied = await applyChanges(event);
-    if (!applied) window.location.reload();
-  }));
-
-  main?.addEventListener('aue:ui-select', handleSelection);
-}
-
 function findComponentDef(componentDefinitions, filter) {
   for (const group of componentDefinitions.groups) {
     for (const component of group.components) {
@@ -179,6 +163,25 @@ async function rewriteBlockLabels(main, blocks = ['Table']) {
       }
     }));
   }
+}
+
+function attachEventListners(main) {
+  [
+    'aue:content-patch',
+    'aue:content-update',
+    'aue:content-add',
+    'aue:content-move',
+    'aue:content-remove',
+  ].forEach((eventType) => main?.addEventListener(eventType, async (event) => {
+    event.stopPropagation();
+    const applied = await applyChanges(event);
+    if (!applied) window.location.reload();
+    else {
+      rewriteBlockLabels(main);
+    }
+  }));
+
+  main?.addEventListener('aue:ui-select', handleSelection);
 }
 
 attachEventListners(document.querySelector('main'));

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -190,7 +190,7 @@ function removeInstrumentation(editable) {
 
 function observePlaceholders(main) {
   new MutationObserver((mutations) => mutations.forEach(({ addedNodes }) => {
-    const placeholderSpan = [...addedNodes].find((node) => node.tagName === 'SPAN' && node.dataset.placeholder)
+    const placeholderSpan = [...addedNodes].find((node) => node.tagName === 'SPAN' && node.dataset.placeholder);
     if (placeholderSpan) {
       // remove instrumentation from the closes richtext or text
       const editable = placeholderSpan.closest('[data-aue-type="richtext"],[data-aue-type="text"]');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -32,7 +32,7 @@ export function moveAttributes(from, to, attributes) {
   attributes.forEach((attr) => {
     const value = from.getAttribute(attr);
     if (value) {
-      to.setAttribute(attr, value);
+      to?.setAttribute(attr, value);
       from.removeAttribute(attr);
     }
   });
@@ -169,7 +169,7 @@ export function formatPlaceholder(context, placeholderName, placeholderValue) {
   return placeholderValue;
 }
 
-export async function replacePlaceholders(main) {
+export async function replacePlaceholders(el) {
   async function fetchAndReplace(context, placeholder) {
     context = context.closest('[class*="loan-type-"]');
 
@@ -187,18 +187,17 @@ export async function replacePlaceholders(main) {
     return placeholders[placeholder] || '';
   }
 
-  const now = new Date();
   const filter = ({ nodeValue }) => (nodeValue.trim()
     ? NodeFilter.FILTER_ACCEPT
     : NodeFilter.FILTER_REJECT);
-  const treeWalker = document.createTreeWalker(main, NodeFilter.SHOW_TEXT, filter);
+  const treeWalker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, filter);
   const replacements = [];
   let currentNode;
   // eslint-disable-next-line no-cond-assign
   while ((currentNode = treeWalker.nextNode()) !== null) {
     const { nodeValue: text } = currentNode;
     const parent = currentNode.parentElement;
-    const matches = [...text.matchAll(/{{([^}]+)}}/g)];
+    const matches = [...text.matchAll(/{([a-z0-9-]+)}/g)];
     const nodes = [];
     for (let i = 0; i < matches.length; i += 1) {
       const match = matches[i];
@@ -229,7 +228,6 @@ export async function replacePlaceholders(main) {
   }
   // eslint-disable-next-line no-shadow
   replacements.forEach(({ currentNode, nodes }) => currentNode.replaceWith(...nodes));
-  console.log(`Replaced ${replacements.length} placeholders in ${new Date() - now}ms`);
 }
 
 /**
@@ -296,7 +294,6 @@ async function loadLazy(doc) {
   autolinkModals(doc);
 
   const main = doc.querySelector('main');
-  await replacePlaceholders(main);
   await loadBlocks(main);
 
   const { hash } = window.location;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-param-reassign */
+
 import {
   sampleRUM,
   loadHeader,
@@ -11,6 +13,8 @@ import {
   loadBlocks,
   loadCSS,
   getMetadata,
+  fetchPlaceholders,
+  toClassName,
 } from './aem.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
@@ -96,6 +100,138 @@ function decorateImageIcons(element, prefix = '') {
   });
 }
 
+async function fetchLoanData(prefix = 'default') {
+  window.loanData = window.loanData || {};
+  if (!window.loanData[prefix]) {
+    window.loanData[prefix] = new Promise((resolve) => {
+      fetch(`${prefix === 'default' ? '' : prefix}/loan-key-features.json`)
+        .then((resp) => (resp.ok ? resp.json() : {}))
+        .then((json) => {
+          const loanData = json.data
+            .filter(({ id }) => Boolean(id))
+            .reduce((acc, { id, ...rest }) => {
+              const newEntries = Object.keys(rest).map((key) => [toClassName(key), rest[key]]);
+              return { ...acc, [id]: Object.fromEntries(newEntries) };
+            }, {});
+          window.loanData[prefix] = loanData;
+          resolve(loanData);
+        })
+        .catch(() => {
+          // error loading loanData
+          window.loanData[prefix] = {};
+          resolve(window.loanData[prefix]);
+        });
+    });
+  }
+  return window.loanData[`${prefix}`];
+}
+
+export function formatPlaceholder(context, placeholderName, placeholderValue) {
+  const locale = document.querySelector('html')?.lang || 'en-IN';
+  const twoDigitOptions = { minimumFractionDigits: 2, maximumFractionDigits: 2 };
+  if (placeholderName.indexOf('rate') >= 0) {
+    // apply percentage formatting to number
+    const numericValue = parseFloat(placeholderValue);
+    if (!Number.isNaN(numericValue)) {
+      placeholderValue = `${numericValue.toLocaleString(locale, twoDigitOptions)}%`;
+    }
+  }
+  if (placeholderName.indexOf('amount') >= 0) {
+    // apply currency formatting to number
+    context = context.closest('[class*="currency-format-"]');
+    const numericValue = parseInt(placeholderValue, 10);
+    if (context && !Number.isNaN(numericValue)) {
+      const currencyFormat = [...context.classList].find((cls) => cls.startsWith('currency-format-')).substring(16);
+      if (currencyFormat === 'long') {
+        // add thousand separators
+        while (/(\d+)(\d{3})/.test(placeholderValue)) {
+          placeholderValue = placeholderValue.replace(/(\d+)(\d{3})/, '$1,$2');
+        }
+      }
+      if (currencyFormat === 'short' || currencyFormat === 'phonetic') {
+        const crores = numericValue / 10000000;
+        const lhakhs = numericValue / 100000;
+        if (crores >= 1) {
+          const suffix = currencyFormat === 'phonetic' ? 'Crore' : 'Cr';
+          placeholderValue = `${crores.toFixed(0)} ${suffix}`;
+        } else {
+          const suffix = currencyFormat === 'phonetic' ? 'Lakhs' : 'L';
+          if (lhakhs >= 1) {
+            placeholderValue = `${lhakhs.toFixed(0)} ${suffix}`;
+          } else {
+            placeholderValue = `${lhakhs.toLocaleString(locale, twoDigitOptions)} ${suffix}`;
+          }
+        }
+      }
+    }
+  }
+
+  return placeholderValue;
+}
+
+export async function replacePlaceholders(main) {
+  async function fetchAndReplace(context, placeholder) {
+    context = context.closest('[class*="loan-type-"]');
+
+    if (context) {
+      // give a loan-type-* context we try to find the placeholder in the loan data
+      const loanType = [...context.classList].find((cls) => cls.startsWith('loan-type-')).substring(10);
+      const allLoanData = await fetchLoanData();
+      const loadData = allLoanData?.[loanType];
+      if (loadData && loadData[placeholder]) {
+        return loadData[placeholder];
+      }
+    }
+
+    const placeholders = fetchPlaceholders();
+    return placeholders[placeholder] || '';
+  }
+
+  const now = new Date();
+  const filter = ({ nodeValue }) => (nodeValue.trim()
+    ? NodeFilter.FILTER_ACCEPT
+    : NodeFilter.FILTER_REJECT);
+  const treeWalker = document.createTreeWalker(main, NodeFilter.SHOW_TEXT, filter);
+  const replacements = [];
+  let currentNode;
+  // eslint-disable-next-line no-cond-assign
+  while ((currentNode = treeWalker.nextNode()) !== null) {
+    const { nodeValue: text } = currentNode;
+    const parent = currentNode.parentElement;
+    const matches = [...text.matchAll(/{{([^}]+)}}/g)];
+    const nodes = [];
+    for (let i = 0; i < matches.length; i += 1) {
+      const match = matches[i];
+      const { index } = match;
+      const [fullMatch, placeholder] = match;
+      if (i === 0 && index > 0) {
+        // prefix only for the first match
+        nodes.push(document.createTextNode(text.slice(0, index)));
+      }
+      const span = document.createElement('span');
+      span.dataset.placeholder = placeholder;
+      // eslint-disable-next-line no-await-in-loop
+      span.textContent = await fetchAndReplace(parent, placeholder);
+      span.textContent = formatPlaceholder(parent, placeholder, span.textContent);
+      nodes.push(span);
+      if (index + fullMatch.length < text.length) {
+        let nextNode;
+        if (i + 1 < matches.length) {
+          const nextMatch = matches[i + 1];
+          nextNode = document.createTextNode(text.slice(index + fullMatch.length, nextMatch.index));
+        } else {
+          nextNode = document.createTextNode(text.slice(index + fullMatch.length));
+        }
+        nodes.push(nextNode);
+      }
+    }
+    if (nodes.length) replacements.push({ currentNode, nodes });
+  }
+  // eslint-disable-next-line no-shadow
+  replacements.forEach(({ currentNode, nodes }) => currentNode.replaceWith(...nodes));
+  console.log(`Replaced ${replacements.length} placeholders in ${new Date() - now}ms`);
+}
+
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
@@ -160,6 +296,7 @@ async function loadLazy(doc) {
   autolinkModals(doc);
 
   const main = doc.querySelector('main');
+  await replacePlaceholders(main);
   await loadBlocks(main);
 
   const { hash } = window.location;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -156,10 +156,10 @@ export function formatPlaceholder(context, placeholderName, placeholderValue) {
           placeholderValue = `${crores.toFixed(0)} ${suffix}`;
         } else {
           const suffix = currencyFormat === 'phonetic' ? 'Lakhs' : 'L';
-          if (lhakhs >= 1) {
-            placeholderValue = `${lhakhs.toFixed(0)} ${suffix}`;
+          if (lakhs >= 1) {
+            placeholderValue = `${lakhs.toFixed(0)} ${suffix}`;
           } else {
-            placeholderValue = `${lhakhs.toLocaleString(locale, twoDigitOptions)} ${suffix}`;
+            placeholderValue = `${lakhs.toLocaleString(locale, twoDigitOptions)} ${suffix}`;
           }
         }
       }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -150,7 +150,7 @@ export function formatPlaceholder(context, placeholderName, placeholderValue) {
       }
       if (currencyFormat === 'short' || currencyFormat === 'phonetic') {
         const crores = numericValue / 10000000;
-        const lhakhs = numericValue / 100000;
+        const lakhs = numericValue / 100000;
         if (crores >= 1) {
           const suffix = currencyFormat === 'phonetic' ? 'Crore' : 'Cr';
           placeholderValue = `${crores.toFixed(0)} ${suffix}`;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

- table now has rows only, first row becomes the header
- placeholders replaced in all text nodes given the pattern `{[a-z0-9-]+}` of a block (opt-in for performance reasons)
- placeholders fetched either from loan data (if within any element that has a loan-type-* class set), or (fallback) to regular placeholders
- placeholders containing the term `amount` are converted to currency, placeholders containing `rate` to percentage
- the currency format can be set on any parent element with either `currency-format-long` (XXX,XXX,XXX), `currency-format-phonetic` (Lahks), or `currency-format-short` (L) as class
- in-context authoring disabled for any element that has a placeholder as simply focus & blur would persist the placeholder value overwriting the placeholder.

Fix #45


Test URLs:
- Before: https://main--piramal--aemsites.hlx.live/home-loans
- After: https://placeholders--piramal--aemsites.hlx.live/home-loans
