### PR TITLE
fix: make accordion body backround transparent

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -68,7 +68,7 @@
 
 .accordion details[open] .accordion-item-body {
   border-top: 1px solid var(--dark-color);
-  background-color: var(--background-color);
+  background-color: transparent;
 }
 
 .accordion.faq details .accordion-item-label {


### PR DESCRIPTION
The accordion body background should be transparent
<img width="1266" alt="image" src="https://github.com/user-attachments/assets/f0d468b8-1de4-4afd-9dc8-f9cf009eb055">


Test URLs:
- Before: https://main--piramal--aemsites.hlx.page/home-loans
- After: https://fix-accordion-background--piramal--aemsites.hlx.page/home-loans
