### PR TITLE
Move previous block children as header

### DIFF
--- a/blocks/recommended-articles/recommended-articles.css
+++ b/blocks/recommended-articles/recommended-articles.css
@@ -10,6 +10,11 @@
   scrollbar-width: none; /* Firefox */
 }
 
+.block.recommended-articles .art-head h4 {
+  font-weight: 400;
+  font-size:1.25rem;
+}
+
 .block.recommended-articles .article-container::-webkit-scrollbar {
   display: none; /* Safari and Chrome */
 }

--- a/blocks/recommended-articles/recommended-articles.js
+++ b/blocks/recommended-articles/recommended-articles.js
@@ -132,6 +132,8 @@ export default function decorate(block) {
 
   head.classList.add('art-head');
 
+  head.firstElementChild.append(...block.parentElement.previousSibling.children);
+
   div.append(...children);
 
   block.append(div);


### PR DESCRIPTION
Recommended articles block move previous element as heading for block

Fix #66 

Test URLs:
- Before: https://main--piramal--aemsites.hlx.page/home-loans
- After: https://issue-66-article-heading-style--piramal--aemsites.hlx.page/home-loans
