### PR TITLE
Issue 95 : add EMI and Eligiblity Calculator models

### DIFF
--- a/component-definition.json
+++ b/component-definition.json
@@ -567,6 +567,42 @@
           }
         }
       ]
-    }
+    },
+    {
+      "title": "Calculators",
+      "id": "calculators",
+      "components":[
+        {
+          "title": "EMI Calculator",
+          "id": "emi-calculator",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "EMI Calculator",
+                  "model": "emi-calculator"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Eligibility Calculator",
+          "id": "eligibility-calculator",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Eligiblity Calculator",
+                  "model": "eligibility-calculator"
+                }
+              }
+            }
+          }
+        } 
+      ]
+    } 
   ]
 }

--- a/component-filters.json
+++ b/component-filters.json
@@ -117,5 +117,12 @@
     "components": [
       "loan-step"
     ]
+  },
+  {
+    "id": "calculator-section",
+    "components": [
+      "emi-calculator",
+      "eligibility-calculator"
+    ]
   }
 ]

--- a/component-models.json
+++ b/component-models.json
@@ -1588,7 +1588,7 @@
     ]
   },
   {
-    "id": "emi-caclulator",
+    "id": "emi-calculator",
     "fields": [
       {
         "component": "multiselect",
@@ -1633,7 +1633,7 @@
     ]
   },
   {
-    "id": "eligibility-caclulator",
+    "id": "eligibility-calculator",
     "fields": [
       {
         "component": "multiselect",

--- a/component-models.json
+++ b/component-models.json
@@ -1586,5 +1586,95 @@
         "valueType": "string"
       }
     ]
-  }
+  },
+  {
+    "id": "emi-caclulator",
+    "fields": [
+      {
+        "component": "multiselect",
+        "name": "classes",
+        "value": "",
+        "label": "Options",
+        "valueType": "string",
+        "maxSize": 2,
+        "options": [
+          {
+            "name": "Employment Type",
+            "children": [
+              {
+                "name": "I'm Salaried",
+                "value": "employment-type-salaried"
+              },
+              {
+                "name": "I'm doing Business",
+                "value": "employment-type-business"
+              }
+            ]
+          },
+          {
+            "name": "Loan Context",
+            "children": [
+              {
+                "name": "Home Loans",
+                "value": "loan-type-home"
+              },
+              {
+                "name": "Business Loans",
+                "value": "loan-type-business"
+              },
+              {
+                "name": "Personal Loans",
+                "value": "loan-type-personal"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "eligibility-caclulator",
+    "fields": [
+      {
+        "component": "multiselect",
+        "name": "classes",
+        "value": "",
+        "label": "Options",
+        "valueType": "string",
+        "maxSize": 2,
+        "options": [
+          {
+            "name": "Employment Type",
+            "children": [
+              {
+                "name": "I'm Salaried",
+                "value": "employment-type-salaried"
+              },
+              {
+                "name": "I'm doing Business",
+                "value": "employment-type-business"
+              }
+            ]
+          },
+          {
+            "name": "Loan Context",
+            "children": [
+              {
+                "name": "Home Loans",
+                "value": "loan-type-home"
+              },
+              {
+                "name": "Business Loans",
+                "value": "loan-type-business"
+              },
+              {
+                "name": "Personal Loans",
+                "value": "loan-type-personal"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  } 
 ]

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -27,6 +27,27 @@ function setState(block, state) {
   }
 }
 
+// set the filter for an UE editable
+function setUEFilter(element, filter) {
+  element.dataset.aueFilter = filter;
+}
+
+/**
+ * See:
+ * https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/developing/universal-editor/attributes-types#data-properties
+ */
+function updateUEInstrumentation() {
+  const main = document.querySelector('main');
+
+  // ----- if calculator pages, identified by theme
+  if (document.querySelector('body[class^=calculator]')) {
+    // update section filter
+    main.querySelectorAll('.section').forEach((elem) => {
+      setUEFilter(elem, 'calculator-section');
+    });
+  }
+}
+
 async function applyChanges(event) {
   // redecorate default content and blocks on patches (in the properties rail)
   const { detail } = event;
@@ -178,6 +199,7 @@ function attachEventListners(main) {
     if (!applied) window.location.reload();
     else {
       rewriteBlockLabels(main);
+      updateUEInstrumentation();
     }
   }));
 
@@ -203,3 +225,4 @@ const m = document.querySelector('main');
 attachEventListners(m);
 rewriteBlockLabels(m);
 observePlaceholders(m);
+updateUEInstrumentation();


### PR DESCRIPTION
- adds EMI and eligibility calculator model definitions
- restricts calculator block selection to calculator templates

Fix #95 

Test URLs:
- Before:
https://main--piramal--aemsites.hlx.page/home-loan

- After: 
https://issue-95--piramal--aemsites.hlx.page/home-loan
Calculator page in UE:
https://author-p133703-e1305981.adobeaemcloud.com/ui#/@piramal/aem/universal-editor/canvas/author-p133703-e1305981.adobeaemcloud.com/content/piramalfinance-eds2/fragments/calculators/home-loan-eligibility-salaried.html?ref=issue-95

